### PR TITLE
Add Windows release workflow and requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build executable
+        run: pyinstaller --onefile --windowed --name RA2-Viewer main.py
+
+      - name: Prepare release package
+        shell: pwsh
+        run: |
+          $stageDir = "release\RA2-Viewer"
+          New-Item -ItemType Directory -Path $stageDir -Force
+
+          # Copy the built exe
+          Copy-Item "dist\RA2-Viewer.exe" -Destination $stageDir
+
+          # Copy required asset directories
+          Copy-Item -Recurse "cameos"       -Destination "$stageDir\cameos"
+          Copy-Item -Recurse "Flags"        -Destination "$stageDir\Flags"
+          Copy-Item -Recurse "icons"        -Destination "$stageDir\icons"
+          Copy-Item -Recurse "Other"        -Destination "$stageDir\Other"
+          Copy-Item -Recurse "oil counts"   -Destination "$stageDir\oil counts"
+
+          # Copy config files
+          Copy-Item "unit_selection.json"    -Destination $stageDir
+
+          # Create the zip archive
+          Compress-Archive -Path $stageDir -DestinationPath "release\RA2-Viewer-${{ github.ref_name }}.zip"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/RA2-Viewer-${{ github.ref_name }}.zip
+          generate_release_notes: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PySide6
+psutil


### PR DESCRIPTION
Add a new GitHub Actions workflow to build and release a Windows executable. The workflow (/.github/workflows/release.yml) runs on windows-latest, sets up Python 3.12, installs requirements and pyinstaller, builds RA2-Viewer via pyinstaller, stages the exe and asset directories (cameos, Flags, icons, Other, oil counts) plus unit_selection.json into release/RA2-Viewer, compresses it to release/RA2-Viewer-${{ github.ref_name }}.zip, and creates a GitHub Release using softprops/action-gh-release. Also add requirements.txt listing PySide6 and psutil.